### PR TITLE
Add the ability to set group background colours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 todo
+web-ext-artifacts/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2018 Danny Y.
+Copyright (c) 2019 Celti B.
+Portions Copyright (c) 2017-2018 Danny Y.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-## Power Tabs
-
-A Firefox WebExtension that provides tab grouping functionality in a vertical manner.
+## Vertical Tab Groups
+A Firefox addon that provides a tab sidebar with tab groups. Forked from [Power Tabs](https://github.com/Rapptz/power-tabs/).
 
 Requires Firefox 57+.
 
 ## License
+Except where otherwise noted, this project is licensed under the terms of the [MIT license](LICENSE).
 
-Code is licensed under MIT.
-
-Icons are licensed under MPL-2.0
+Project icons are licensed under the MPL-2.0

--- a/background/listen.js
+++ b/background/listen.js
@@ -39,6 +39,7 @@ var _showActiveGroupBadge = true;
 var _hideOnGroupChange = true;
 var _enablePopup = true;
 var _defaultColour = '#000000';
+var _defaultBgColour = '#ededf0';
 var _freshInstallBaton = null;
 
 // windowId -> groupId for last active group
@@ -314,7 +315,8 @@ async function createGroup(windowId, sendResponse=null) {
     uuid: uuid4(),
     open: true,
     active: true,
-    colour: _defaultColour
+    colour: _defaultColour,
+    background: _defaultBgColour
   };
 
   _groups.push(newGroup);
@@ -514,7 +516,8 @@ async function ensureDefaultSettings() {
     showActiveGroupBadge: true,
     enablePopup: true,
     darkTheme: false,
-    defaultColour: '#000000'
+    defaultColour: '#000000',
+    defaultBgColour: '#ededf0'
   };
 
   let keys = Object.keys(settings);
@@ -550,6 +553,7 @@ async function actualFreshInstall() {
     uuid: uuid4(),
     name: "untitled",
     colour: _defaultColour,
+    background: _defaultBgColour,
     active: true,
     open: true
   };
@@ -702,6 +706,10 @@ function onSettingChange(changes, area) {
 
   if(changes.hasOwnProperty("defaultColour")) {
     _defaultColour = changes.defaultColour.newValue;
+  }
+
+  if(changes.hasOwnProperty("defaultBgColour")) {
+    _defaultBgColour = changes.defaultBgColour.newValue;
   }
 
   if(changes.hasOwnProperty("groups")) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
     "manifest_version": 2,
-    "name": "Power Tabs",
-    "version": "1.8.0",
-    "homepage_url": "https://github.com/Rapptz/power-tabs",
+    "name": "Vertical Tab Groups",
+    "version": "0.1.0",
+    "homepage_url": "https://github.com/Celti/vertical-tab-groups",
     "description": "Vertical tab groups with tab searching",
-    "applications": {
+    "browser_specific_settings": {
         "gecko": {
-            "id": "power-tabs@rapptz-addons.com",
+            "id": "vertical-tab-groups@celti.name",
             "strict_min_version": "57.0"
         }
     },
@@ -29,7 +29,7 @@
             "suggested_key": {
                 "default": "Ctrl+Shift+Comma"
             },
-            "description": "Opens the Power Tab menu."
+            "description": "Opens the Vertical Tab Groups menu."
         },
         "_execute_browser_action": {
             "suggested_key": {
@@ -137,7 +137,7 @@
     },
 
     "sidebar_action": {
-        "default_title": "Power Tabs",
+        "default_title": "Vertical Tab Groups",
         "default_panel": "sidebar/main.html",
         "default_icon": "icons/icon.svg",
         "browser_style": true
@@ -146,7 +146,7 @@
     "browser_action": {
         "browser_style": true,
         "default_icon": "icons/icon.svg",
-        "default_title": "Power Tabs"
+        "default_title": "Vertical Tab Groups"
     },
 
     "web_accessible_resources": [

--- a/options/options.html
+++ b/options/options.html
@@ -61,12 +61,13 @@
     </div>
     <div class="settings-group">
       <div class="label">
-        Default group color
+        Default group colors
         <div class="aside">
-          <p>New groups are created with this color</p>
+          <p>New groups are created with these colors</p>
         </div>
       </div>
       <input class="setting" type="color" id="defaultColour">
+      <input class="setting" type="color" id="defaultBgColour">
     </div>
   </form>
   <div class="create-group-container">
@@ -88,8 +89,12 @@
           <input class="setting" id="groupName" type="text">
         </div>
         <div class="settings-group">
-          <span class="label">Color</span>
+          <span class="label">Foreground Color</span>
           <input class="setting" id="groupColour" type="color">
+        </div>
+        <div class="settings-group">
+          <span class="label">Background Color</span>
+          <input class="setting" id="groupBgColour" type="color">
         </div>
         <div class="settings-group">
           <div class="label">

--- a/options/options.js
+++ b/options/options.js
@@ -65,6 +65,15 @@ class GroupSetting {
       this.save();
     });
 
+    let backgroundEdit = templ.getElementById("groupBgColour");
+    backgroundEdit.id = "";
+    backgroundEdit.value = this.data.hasOwnProperty("background") ? this.data.background : '#ededf0';
+
+    backgroundEdit.addEventListener("change", (e) => {
+      this.data.background = backgroundEdit.value;
+      this.save();
+    });
+
     let assignedDomains = templ.getElementById("assignedDomains");
     assignedDomains.id = "";
     this._assignedDomains = assignedDomains;
@@ -200,6 +209,12 @@ function loadRegularSettings(data) {
   defaultColour.value = data.defaultColour;
   defaultColour.addEventListener("change", (e) => {
     saveSettings("defaultColour", defaultColour.value);
+  });
+
+  let defaultBgColour = document.getElementById("defaultBgColour");
+  defaultBgColour.value = data.defaultBgColour;
+  defaultBgColour.addEventListener("change", (e) => {
+    saveSettings("defaultBgColour", defaultBgColour.value);
   });
 }
 

--- a/popup/main.js
+++ b/popup/main.js
@@ -62,6 +62,7 @@ class Tab {
     groupBadge.className = "group-badge";
     groupBadge.title = parent.name;
     groupBadge.style.color = parent.colour;
+    groupBadge.style.backgroundColor = parent.background;
 
     let icon = createIcon(data.hasOwnProperty('favIconUrl') ? data.favIconUrl : null);
     let name = document.createElement("div");
@@ -125,6 +126,7 @@ class Group {
     this.open = data.open;
     this.active = data.active;
     this.colour = data.colour || '#000000';
+    this.background = data.background || '#ededf0';
     this.tabs = [];
   }
 
@@ -138,7 +140,8 @@ class Group {
       uuid: this.uuid,
       open: this.open,
       active: this.active,
-      colour: this.colour
+      colour: this.colour,
+      background: this.background
     };
   }
 
@@ -189,6 +192,7 @@ class Group {
     groupName.className = "group-name";
     groupName.textContent = this.name;
     groupName.style.color = this.colour;
+    groupName.style.backgroundColor = this.background;
     this._groupName = groupName;
 
     let tabCount = document.createElement("span");

--- a/sidebar/group.js
+++ b/sidebar/group.js
@@ -8,6 +8,7 @@ class Group {
       this.open = args.open;
       this.active = args.active;
       this.colour = args.hasOwnProperty('colour') ? args.colour : '#000000';
+      this.background = args.hasOwnProperty('background') ? args.background : '#ededf0';
     }
     else {
       this.name = args;
@@ -15,6 +16,7 @@ class Group {
       this.open = true;
       this.active = false;
       this.colour = '#000000';
+      this.background = '#ededf0';
     }
 
     this.parent = null;
@@ -73,6 +75,7 @@ class Group {
     summary.className = "tab-group-container";
     this._summaryView = summary;
     summary.style.color = this.colour;
+    summary.style.backgroundColor = this.background;
 
     let summaryIcon = document.createElement("div");
     summaryIcon.className = "summary-icon";
@@ -680,7 +683,8 @@ class Group {
       uuid: this.uuid,
       open: this.open,
       active: this.active,
-      colour: this.colour
+      colour: this.colour,
+      background: this.background
     };
   }
 

--- a/sidebar/tab.js
+++ b/sidebar/tab.js
@@ -41,6 +41,20 @@ class TabEntry {
       this.changeTab()
     });
 
+    // inhibit autoscroll
+    tab.addEventListener("mousedown", (e) => {
+      if(e.button == 1) {
+        e.preventDefault();
+      }
+    });
+
+    // close tab on middle-click
+    tab.addEventListener("auxclick", (e) => {
+      if(e.button == 1) {
+        this.close();
+      }
+    });
+
     tab.title = this.title;
 
     this.view = tab;


### PR DESCRIPTION
This allows setting a group's background colour independently from the theme and the foreground colour, on the theory that it's much easier to tell apart large blocks of different colours at a glance (as opposed to thin lines of colour within blocks of uniform grey).

As far as my testing shows, this is mostly compatible with all other features, with the two caveats that
1. The default foreground and background do *not* change when switching to to the dark theme.
2. The toolbar badge is still hooked on the foreground colour.

For 1, as far as I could tell the previous FG-only setting also did not change on dark theme selection, so this may not be an issue.
For 2, perhaps one could compare two colours by saturation/brightness and choose the richer/darker one (given that Firefox sets all badge foregrounds to white at this time)?