### PR TITLE
Close tabs on middle-click in sidebar

### DIFF
--- a/sidebar/tab.js
+++ b/sidebar/tab.js
@@ -41,6 +41,20 @@ class TabEntry {
       this.changeTab()
     });
 
+    // inhibit autoscroll
+    tab.addEventListener("mousedown", (e) => {
+      if(e.button == 1) {
+        e.preventDefault();
+      }
+    });
+
+    // close tab on middle-click
+    tab.addEventListener("auxclick", (e) => {
+      if(e.button == 1) {
+        this.close();
+      }
+    });
+
     tab.title = this.title;
 
     this.view = tab;


### PR DESCRIPTION
This brings the sidebar's middle-click handling in line with the horizontal tab-bar.